### PR TITLE
fix: improve LelManga source with correct chapter numbering and URLs

### DIFF
--- a/src/rust/madara/sources/lelmanga/res/source.json
+++ b/src/rust/madara/sources/lelmanga/res/source.json
@@ -3,7 +3,7 @@
     "id": "fr.lelmanga",
     "lang": "fr",
     "name": "LelManga",
-    "version": 3,
+    "version": 4,
     "url": "https://www.lelmanga.com",
     "nsfw": 0
   },

--- a/src/rust/madara/sources/lelmanga/res/source.json
+++ b/src/rust/madara/sources/lelmanga/res/source.json
@@ -3,7 +3,7 @@
     "id": "fr.lelmanga",
     "lang": "fr",
     "name": "LelManga",
-    "version": 7,
+    "version": 3,
     "url": "https://www.lelmanga.com",
     "nsfw": 0
   },

--- a/src/rust/madara/sources/lelmanga/res/source.json
+++ b/src/rust/madara/sources/lelmanga/res/source.json
@@ -3,7 +3,7 @@
     "id": "fr.lelmanga",
     "lang": "fr",
     "name": "LelManga",
-    "version": 4,
+    "version": 5,
     "url": "https://www.lelmanga.com",
     "nsfw": 0
   },

--- a/src/rust/madara/sources/lelmanga/res/source.json
+++ b/src/rust/madara/sources/lelmanga/res/source.json
@@ -3,7 +3,7 @@
     "id": "fr.lelmanga",
     "lang": "fr",
     "name": "LelManga",
-    "version": 6,
+    "version": 7,
     "url": "https://www.lelmanga.com",
     "nsfw": 0
   },

--- a/src/rust/madara/sources/lelmanga/res/source.json
+++ b/src/rust/madara/sources/lelmanga/res/source.json
@@ -3,7 +3,7 @@
     "id": "fr.lelmanga",
     "lang": "fr",
     "name": "LelManga",
-    "version": 2,
+    "version": 3,
     "url": "https://www.lelmanga.com",
     "nsfw": 0
   },

--- a/src/rust/madara/sources/lelmanga/res/source.json
+++ b/src/rust/madara/sources/lelmanga/res/source.json
@@ -3,7 +3,7 @@
     "id": "fr.lelmanga",
     "lang": "fr",
     "name": "LelManga",
-    "version": 5,
+    "version": 6,
     "url": "https://www.lelmanga.com",
     "nsfw": 0
   },

--- a/src/rust/madara/sources/lelmanga/src/lib.rs
+++ b/src/rust/madara/sources/lelmanga/src/lib.rs
@@ -351,7 +351,7 @@ fn get_chapter_list(id: String) -> Result<Vec<Chapter>> {
 			chapter: chapter_num,
 			date_updated,
 			scanlator: String::new(),
-			url: String::new(),
+			url: href,
 			lang: data.lang.clone(),
 		});
 	}

--- a/src/rust/madara/sources/lelmanga/src/lib.rs
+++ b/src/rust/madara/sources/lelmanga/src/lib.rs
@@ -383,7 +383,7 @@ fn extract_chapter_number(chapter_id: &str, title: &str) -> f32 {
 	}
 	
 	// New logic for lelmanga format: manga-name-XXX-Y where XXX is chapter number and Y is version/part
-	// Split by '-' and look for the pattern where we have a large number followed by a small number
+	// Split by '-' and look for the pattern where we have a chapter number followed by a small suffix
 	let parts: Vec<&str> = chapter_id.split('-').collect();
 	if parts.len() >= 2 {
 		let last_part = parts[parts.len() - 1];
@@ -391,12 +391,9 @@ fn extract_chapter_number(chapter_id: &str, title: &str) -> f32 {
 		
 		// Try to parse both parts as numbers
 		if let (Ok(last_num), Ok(second_last_num)) = (last_part.parse::<f32>(), second_last_part.parse::<f32>()) {
-			// If last number is small (likely a version/part) and second last is larger (likely chapter number)
-			if last_num <= 10.0 && second_last_num > 10.0 {
-				return second_last_num;
-			}
-			// If only one big number, prefer the larger one
-			if second_last_num > last_num && second_last_num > 10.0 {
+			// If last number is small (likely a version/part) and second last is >= last (likely chapter number)
+			// Use more flexible logic: if last number ≤ 20 and second_last ≥ last, prefer second_last
+			if last_num <= 20.0 && second_last_num >= last_num {
 				return second_last_num;
 			}
 		}

--- a/src/rust/madara/sources/lelmanga/src/lib.rs
+++ b/src/rust/madara/sources/lelmanga/src/lib.rs
@@ -382,6 +382,26 @@ fn extract_chapter_number(chapter_id: &str, title: &str) -> f32 {
 		}
 	}
 	
+	// New logic for lelmanga format: manga-name-XXX-Y where XXX is chapter number and Y is version/part
+	// Split by '-' and look for the pattern where we have a large number followed by a small number
+	let parts: Vec<&str> = chapter_id.split('-').collect();
+	if parts.len() >= 2 {
+		let last_part = parts[parts.len() - 1];
+		let second_last_part = parts[parts.len() - 2];
+		
+		// Try to parse both parts as numbers
+		if let (Ok(last_num), Ok(second_last_num)) = (last_part.parse::<f32>(), second_last_part.parse::<f32>()) {
+			// If last number is small (likely a version/part) and second last is larger (likely chapter number)
+			if last_num <= 10.0 && second_last_num > 10.0 {
+				return second_last_num;
+			}
+			// If only one big number, prefer the larger one
+			if second_last_num > last_num && second_last_num > 10.0 {
+				return second_last_num;
+			}
+		}
+	}
+	
 	// Fallback: try to extract from the last segment of URL (original behavior)
 	if let Some(num_str) = chapter_id.split('-').last() {
 		if let Ok(num) = num_str.parse::<f32>() {

--- a/src/rust/madara/sources/lelmanga/src/lib.rs
+++ b/src/rust/madara/sources/lelmanga/src/lib.rs
@@ -344,6 +344,15 @@ fn get_chapter_list(id: String) -> Result<Vec<Chapter>> {
 		let date_str = obj.select(".chapterdate").text().read();
 		let date_updated = parse_chapter_date(&date_str);
 		
+		// Ensure URL is absolute
+		let full_url = if href.starts_with("http") {
+			href  // Already absolute
+		} else if href.starts_with("/") {
+			format!("{}{}", data.base_url, href)  // Relative with /
+		} else {
+			format!("{}/{}", data.base_url, href)  // Relative without /
+		};
+		
 		chapters.push(Chapter {
 			id: chapter_id,
 			title,
@@ -351,7 +360,7 @@ fn get_chapter_list(id: String) -> Result<Vec<Chapter>> {
 			chapter: chapter_num,
 			date_updated,
 			scanlator: String::new(),
-			url: href,
+			url: full_url,
 			lang: data.lang.clone(),
 		});
 	}

--- a/src/rust/madara/sources/lelmanga/src/lib.rs
+++ b/src/rust/madara/sources/lelmanga/src/lib.rs
@@ -281,7 +281,7 @@ fn get_manga_details(id: String) -> Result<Manga> {
 		author,
 		artist,
 		description,
-		url: String::new(),
+		url,
 		categories,
 		status,
 		nsfw,
@@ -360,7 +360,29 @@ fn get_chapter_list(id: String) -> Result<Vec<Chapter>> {
 }
 
 fn extract_chapter_number(chapter_id: &str, title: &str) -> f32 {
-	// First try to extract from URL ID
+	// First try to extract from URL ID by looking for "chapitre-XXX" or "chapter-XXX" pattern
+	let chapter_id_lower = chapter_id.to_lowercase();
+	
+	// Look for the pattern "chapitre-" or "chapter-" followed by a number
+	if let Some(chapitre_pos) = chapter_id_lower.find("chapitre-") {
+		let after_chapitre = &chapter_id[chapitre_pos + 9..]; // 9 is length of "chapitre-"
+		if let Some(num_str) = after_chapitre.split('-').next() {
+			if let Ok(num) = num_str.parse::<f32>() {
+				return num;
+			}
+		}
+	}
+	
+	if let Some(chapter_pos) = chapter_id_lower.find("chapter-") {
+		let after_chapter = &chapter_id[chapter_pos + 8..]; // 8 is length of "chapter-"
+		if let Some(num_str) = after_chapter.split('-').next() {
+			if let Ok(num) = num_str.parse::<f32>() {
+				return num;
+			}
+		}
+	}
+	
+	// Fallback: try to extract from the last segment of URL (original behavior)
 	if let Some(num_str) = chapter_id.split('-').last() {
 		if let Ok(num) = num_str.parse::<f32>() {
 			return num;


### PR DESCRIPTION
## Summary
- Fix chapter number extraction for LelManga URL format (manga-name-XXX-Y)
- Add manga and chapter URLs for better navigation
- Support flexible chapter numbering for all digit counts (1-4+ digits)

## Changes
- **Chapter numbering**: Fixed extraction from URLs like `hunter-x-hunter-398-2` to return 398 instead of 2
- **Flexible logic**: Handles all chapter formats from 1 digit to 4+ digits with suffixes ≤ 20
- **URLs**: Added absolute URLs for manga details and individual chapters
- **Compatibility**: Maintains backward compatibility with existing URL formats

## Test cases
- ✅ `one-piece-1126-2` → Ch.1126 (4 digits)
- ✅ `hunter-x-hunter-398-2` → Ch.398 (3 digits)  
- ✅ `manga-5-2` → Ch.5 (1 digit)
- ✅ `manga-403` → Ch.403 (without suffix)

## Files modified
- `src/rust/madara/sources/lelmanga/src/lib.rs`
- `src/rust/madara/sources/lelmanga/res/source.json`